### PR TITLE
add prefixes to all components.

### DIFF
--- a/data/base.json
+++ b/data/base.json
@@ -1,6 +1,7 @@
 {
 	"base": {
 		"prefix": "",
+		"prefix-grid": "",
 		"border-radius": "3px",
 		"space": "1rem",
 		"font-size": "16px",

--- a/src/scss/components/blockquote/_index.scss
+++ b/src/scss/components/blockquote/_index.scss
@@ -1,5 +1,5 @@
 @mixin henris-blockquote($el: 'blockquote'){
-	#{$el} {
+	#{$base-prefix}#{$el} {
 		position: relative;
 		display: inline-block;
 		border: 1px solid color(Black, 0.2);

--- a/src/scss/components/button/_button.scss
+++ b/src/scss/components/button/_button.scss
@@ -96,7 +96,7 @@ $button-font-weight: 600 !default; //
 		$el: #{$class}, button;
 	}
 
-	#{$el} {
+	#{$base-prefix}#{$el} {
 		// ------------------------------------------------------------------------ */
 		//	Styling set on standard buttons and elements with a button class	   */
 		// ---------------------------------------------------------------------- */

--- a/src/scss/components/card/_index.scss
+++ b/src/scss/components/card/_index.scss
@@ -1,5 +1,5 @@
 @mixin henris-card($el: '.card') {
-	#{$el} {
+	#{$base-prefix}#{$el} {
 		border-radius: $base-border-radius;
 		position: relative;
 		@content;
@@ -42,7 +42,7 @@
 			}
 		}
 	}
-	.column #{$el} {
+	.column #{$base-prefix}#{$el} {
 		height: 100%;
 	}
 }

--- a/src/scss/components/detail-list/_index.scss
+++ b/src/scss/components/detail-list/_index.scss
@@ -1,5 +1,5 @@
 @mixin henris-detail-list($el: 'dl') {
-	#{$el} {
+	#{$base-prefix}#{$el} {
 		margin: 0px;
 		padding: 0px;
 		overflow: auto;

--- a/src/scss/components/forms/_form.scss
+++ b/src/scss/components/forms/_form.scss
@@ -1,9 +1,9 @@
 @mixin henris-fieldset($el: 'fieldset'){
-	#{$el} {
+	#{$base-prefix}#{$el} {
 		margin: 0;
 		padding: 0;
 		border: none;
-		& + #{$el} {
+		& + #{$base-prefix}#{$el} {
 			margin-top: grid(0.5);
 			border-top: 1px solid color(Black, 0.1);
 			@include min-("margin-top", 0.5, 16);
@@ -44,7 +44,7 @@
 	}
 
 	form {
-		#{$el} {
+		#{$base-prefix}#{$el} {
 			div:not([class]) {
 				& + div:not([class]) {
 					margin-top: 1rem;
@@ -103,7 +103,7 @@
 			transform: scale(1, -1) rotate(90deg);
 		}
 	}
-	#{$el} {
+	#{$base-prefix}#{$el} {
 		legend {
 			font-weight: bold;
 			text-transform: uppercase;

--- a/src/scss/components/forms/_input-check-color.scss
+++ b/src/scss/components/forms/_input-check-color.scss
@@ -1,5 +1,5 @@
 @mixin henris-check-color($el: '.input-check-color') {
-	#{$el} {
+	#{$base-prefix}#{$el} {
 		height: auto;
 		width: auto;
 		padding: 0;

--- a/src/scss/components/forms/_input-check-icon.scss
+++ b/src/scss/components/forms/_input-check-icon.scss
@@ -1,5 +1,5 @@
 @mixin henris-check-icon($el: '.input-check-icon') {
-	#{$el} {
+	#{$base-prefix}#{$el} {
 		height: auto;
 		width: auto;
 		padding: 0;

--- a/src/scss/components/forms/_input-check-text.scss
+++ b/src/scss/components/forms/_input-check-text.scss
@@ -1,5 +1,5 @@
 @mixin henris-check-text($el: '.input-check-text') {
-	#{$el} {
+	#{$base-prefix}#{$el} {
 		height: auto;
 		width: auto;
 		padding: 0;

--- a/src/scss/components/forms/_input-checkbox.scss
+++ b/src/scss/components/forms/_input-checkbox.scss
@@ -7,7 +7,7 @@
 		max-width: auto;
 		min-width: auto;
 	}
-	#{$el} {
+	#{$base-prefix}#{$el} {
 		height: auto;
 		width: auto;
 		padding: 0;

--- a/src/scss/components/forms/_input-field.scss
+++ b/src/scss/components/forms/_input-field.scss
@@ -1,5 +1,5 @@
 @mixin henris-input-field($el: '.input,.input-field') {
-	#{$el} {
+	#{$base-prefix}#{$el} {
 		@content;
 	}
 }

--- a/src/scss/components/forms/_input-hidden.scss
+++ b/src/scss/components/forms/_input-hidden.scss
@@ -1,5 +1,5 @@
 @mixin henris-hidden($el: 'input.hidden') {
-	#{$el} {
+	#{$base-prefix}#{$el} {
 		width: 0;
 		height: 0;
 		opacity: 0;

--- a/src/scss/components/forms/_input-range.scss
+++ b/src/scss/components/forms/_input-range.scss
@@ -1,5 +1,5 @@
 @mixin henris-input-range($el: '.input-range') {
-	#{$el} {
+	#{$base-prefix}#{$el} {
 		display: flex;
 		[type='range'] {
 			-webkit-appearance: none;

--- a/src/scss/components/forms/_input-switch.scss
+++ b/src/scss/components/forms/_input-switch.scss
@@ -1,5 +1,5 @@
 @mixin henris-input-switch($el: '.input-switch') {
-	#{$el} {
+	#{$base-prefix}#{$el} {
 		display: inline-block;
 		position: relative;
 		input[type='checkbox'] {

--- a/src/scss/components/forms/_input.scss
+++ b/src/scss/components/forms/_input.scss
@@ -1,5 +1,5 @@
 @mixin henris-input($el: '.input-field'){
-	#{$el} {
+	#{$base-prefix}#{$el} {
 		input {
 			&[type='text'],
 			&[type='email'],

--- a/src/scss/components/forms/_label.scss
+++ b/src/scss/components/forms/_label.scss
@@ -1,5 +1,5 @@
 @mixin henris-label($el: 'label') {
-	#{$el} {
+	#{$base-prefix}#{$el} {
 		padding-left: 0;
 		transition: padding-left 0.3s ease-in-out;
 		padding-right: 1rem;

--- a/src/scss/components/forms/_select.scss
+++ b/src/scss/components/forms/_select.scss
@@ -1,6 +1,6 @@
 $select-arrow-size: 0.3rem !default;
 @mixin henris-select($el: 'select') {
-	#{$el} {
+	#{$base-prefix}#{$el} {
 		@include henris-input-default();
 
 		min-width: 12rem;

--- a/src/scss/components/forms/_textarea.scss
+++ b/src/scss/components/forms/_textarea.scss
@@ -1,5 +1,5 @@
 @mixin henris-textarea($el: 'textarea'){
-	#{$el} {
+	#{$base-prefix}#{$el} {
 		@include henris-input-default();
 		resize: none;
 		min-height: 5rem;

--- a/src/scss/components/table/_index.scss
+++ b/src/scss/components/table/_index.scss
@@ -1,9 +1,9 @@
 @mixin henris-table($el: 'table'){
-	#{$el} {
+	#{$base-prefix}#{$el} {
 		border-radius: $base-border-radius;
 		border-collapse: collapse;
 
-		& + #{$el} {
+		& + #{$base-prefix}#{$el} {
 			margin-top: grid(1);
 			@include min-("margin-top", 1, 30);
 		}

--- a/src/scss/grid/_classes.scss
+++ b/src/scss/grid/_classes.scss
@@ -1,5 +1,5 @@
 @if output(grid) {
-	.row {
+	.#{$base-prefix-grid}row {
 		max-width: #{$grid-row-width}px;
 		width: 100%;
 		margin: auto;
@@ -15,23 +15,23 @@
 				grid-gap: 0rem; //
 			}
 		}
-		&.center {
+		&.#{$base-prefix-grid}center {
 			justify-items: center;
 			justify-content: center;
 
 			@if $grid-cssgrid {
-				> .column {
+				> .#{$base-prefix-grid}column {
 					align-self: center;
 					justify-self: center;
 				}
 			}
 		}
-		&.right {
+		&.#{$base-prefix-grid}right {
 			justify-items: right;
 			justify-content: flex-end;
 
 			@if $grid-cssgrid {
-				> .column {
+				> .#{$base-prefix-grid}column {
 					align-self: right;
 					justify-self: right;
 				}
@@ -39,7 +39,7 @@
 		}
 		@each $grid-name, $grid-value in $grid-breakpoints {
 			// @debug $grid-name;
-			&.#{$grid-name}-reverse {
+			&.#{$base-prefix-grid}#{$grid-name}-reverse {
 				$mq: media-query(#{$grid-name}-up);
 				@media #{$mq} {
 					flex-direction: row-reverse;
@@ -47,7 +47,7 @@
 			}
 		}
 	}
-	.column {
+	.#{$base-prefix-grid}column {
 		@include createGridClasses(false);
 	}
 }

--- a/src/scss/grid/_mixins.scss
+++ b/src/scss/grid/_mixins.scss
@@ -51,7 +51,7 @@
 	//
 	$childClass: '';
 	@if $child == true {
-		$childClass: '> .#{$base-prefix}column';
+		$childClass: '> .#{$base-prefix-grid}column';
 	}
 	//
 	// Create the default classes for widths without any media query
@@ -61,7 +61,7 @@
 			$percentage: percentage($a/$grid-columns); //
 			$column: #{$a}#{$childClass};
 			@if output(grid-column) {
-				&.#{$base-prefix}column-#{$column} {
+				&.#{$base-prefix-grid}column-#{$column} {
 					width: #{$percentage};
 					@if output(grid-cssgrid) {
 						@supports (display: grid) {
@@ -71,17 +71,17 @@
 				}
 			}
 			@if output(grid-offset) {
-				&.#{$base-prefix}offset-#{$column} {
+				&.#{$base-prefix-grid}offset-#{$column} {
 					margin-left: #{$percentage};
 				}
 			}
 			@if output(grid-push) {
-				&.#{$base-prefix}push-#{$column} {
+				&.#{$base-prefix-grid}push-#{$column} {
 					margin-right: #{$percentage};
 				}
 			}
 			@if output(grid-pull) {
-				&.#{$base-prefix}pull-#{$column} {
+				&.#{$base-prefix-grid}pull-#{$column} {
 					margin-left: -#{$percentage};
 				}
 			}
@@ -105,7 +105,7 @@
 		@if output('grid-parts') {
 			@each $part, $percentage in $grid-parts {
 				&%#{$part}#{$childClass},
-				&.#{$base-prefix}#{$part}#{$childClass} {
+				&.#{$base-prefix-grid}#{$part}#{$childClass} {
 					width: percentage($percentage);
 					@if $grid-cssgrid == true {
 						@supports (display: grid) {
@@ -122,35 +122,35 @@
 		//
 		@if output('grid-only-classes') {
 			@media #{$mq-only} {
-				&.#{$base-prefix}#{$bp-name}-only-0#{$childClass} {
+				&.#{$base-prefix-grid}#{$bp-name}-only-0#{$childClass} {
 					width: 0;
 					display: none;
 				}
 				@each $part, $percentage in $grid-parts {
 					.#{$bp-name}-only-#{$part}#{$childClass},
-					&.#{$base-prefix}#{$bp-name}-only-#{$part}#{$childClass} {
+					&.#{$base-prefix-grid}#{$bp-name}-only-#{$part}#{$childClass} {
 						width: percentage($percentage);
 					}
 				}
 			}
 			@for $a from 1 through $grid-columns {
 				$percentage: percentage($a/$grid-columns);
-				&.#{$base-prefix}#{$bp-name}-only-#{$a}#{$childClass} {
+				&.#{$base-prefix-grid}#{$bp-name}-only-#{$a}#{$childClass} {
 					width: $percentage;
 				}
 
 				@if output(grid-offset) {
-					&.#{$base-prefix}offset-#{$bp-name}-only-#{$a}#{$childClass} {
+					&.#{$base-prefix-grid}offset-#{$bp-name}-only-#{$a}#{$childClass} {
 						margin-left: $percentage;
 					}
 				}
 				@if output(grid-push) {
-					&.#{$base-prefix}push-#{$bp-name}-only-#{$a}#{$childClass} {
+					&.#{$base-prefix-grid}push-#{$bp-name}-only-#{$a}#{$childClass} {
 						margin-right: $percentage;
 					}
 				}
 				@if output(grid-pull) {
-					&.#{$base-prefix}pull-#{$bp-name}-only-#{$a}#{$childClass} {
+					&.#{$base-prefix-grid}pull-#{$bp-name}-only-#{$a}#{$childClass} {
 						margin-left: -#{$percentage};
 					}
 				}
@@ -162,7 +162,7 @@
 				// Sometimes you need a zero, which does the same as a hide for a breakpoint.
 				//
 				.#{$bp-name}-0#{$childClass}
-					&.#{$base-prefix}#{$bp-name}-0#{$childClass} {
+					&.#{$base-prefix-grid}#{$bp-name}-0#{$childClass} {
 					width: 0;
 					display: none;
 				}
@@ -172,7 +172,7 @@
 				@if output('grid-parts') {
 					@each $part, $percentage in $grid-parts {
 						%#{$bp-name}-#{$part}#{$childClass},
-						&.#{$base-prefix}#{$bp-name}-#{$part}#{$childClass} {
+						&.#{$base-prefix-grid}#{$bp-name}-#{$part}#{$childClass} {
 							width: percentage($percentage);
 
 							@if $grid-cssgrid == true {
@@ -191,7 +191,7 @@
 					@for $a from 1 through $grid-columns {
 						$percentage: percentage($a/$grid-columns);
 
-						&.#{$base-prefix}#{$bp-name}-#{$a}#{$childClass} {
+						&.#{$base-prefix-grid}#{$bp-name}-#{$a}#{$childClass} {
 							width: $percentage;
 							@if $grid-cssgrid == true {
 								@supports (display: grid) {
@@ -202,17 +202,17 @@
 							}
 						}
 						@if output(grid-offset) {
-							&.#{$base-prefix}offset-#{$bp-name}-#{$a}#{$childClass} {
+							&.#{$base-prefix-grid}offset-#{$bp-name}-#{$a}#{$childClass} {
 								margin-left: $percentage;
 							}
 						}
 						@if output(grid-push) {
-							&.#{$base-prefix}push-#{$bp-name}-#{$a}#{$childClass} {
+							&.#{$base-prefix-grid}push-#{$bp-name}-#{$a}#{$childClass} {
 								margin-right: $percentage;
 							}
 						}
 						@if output(grid-pull) {
-							&.#{$base-prefix}pull-#{$bp-name}-#{$a}#{$childClass} {
+							&.#{$base-prefix-grid}pull-#{$bp-name}-#{$a}#{$childClass} {
 								margin-left: -#{$percentage};
 							}
 						}

--- a/src/scss/grid/_mq-classes.scss
+++ b/src/scss/grid/_mq-classes.scss
@@ -1,38 +1,38 @@
 @if output(grid-hide-show-classes) {
 	// Hide classes
-	.hide-for-large-up {
+	.#{$base-prefix-grid}hide-for-large-up {
 		@media #{$large-up} {
 			display: none;
 		}
 	}
-	.hide-for-large-only {
+	.#{$base-prefix-grid}hide-for-large-only {
 		@media #{$large-only} {
 			display: none;
 		}
 	}
-	.hide-for-medium-up {
+	.#{$base-prefix-grid}hide-for-medium-up {
 		@media #{$medium-up} {
 			display: none;
 		}
 	}
-	.hide-for-medium-only {
+	.#{$base-prefix-grid}hide-for-medium-only {
 		@media #{$medium-only} {
 			display: none;
 		}
 	}
-	.hide-for-small {
+	.#{$base-prefix-grid}hide-for-small {
 		@media #{$small-only} {
 			display: none;
 		}
 	}
 
 	// Show classes
-	.show-for-small-only {
+	.#{$base-prefix-grid}show-for-small-only {
 		@media #{$medium-up} {
 			display: none;
 		}
 	}
-	.show-for-medium-only {
+	.#{$base-prefix-grid}show-for-medium-only {
 		@media #{$small-only} {
 			display: none;
 		}
@@ -40,7 +40,7 @@
 			display: none;
 		}
 	}
-	.show-for-large-only {
+	.#{$base-prefix-grid}show-for-large-only {
 		@media #{$medium-down} {
 			display: none;
 		}

--- a/src/scss/settings/_base.scss
+++ b/src/scss/settings/_base.scss
@@ -1,4 +1,5 @@
 $base-prefix: '' !default; //
+$base-prefix-grid: '' !default; //
 $base-border-radius: 3px !default; //
 $base-space: 1rem !default; //
 $base-font-size: 16px !default; //


### PR DESCRIPTION
Default is nothing. But now you can easily set a prefix to all components coming from henris. This could be handy in case you want to extend another framework with henris and will have conflicting classes.

Default prefix for grid has been set on another setting. This because you might want to have a different prefix or no prefixed especially for grid classes in your layout.